### PR TITLE
the majority of administration controls

### DIFF
--- a/server/src/main/java/skybooker/server/controller/AvionController.java
+++ b/server/src/main/java/skybooker/server/controller/AvionController.java
@@ -42,18 +42,22 @@ public class AvionController {
 
     @PostMapping("/")
     @Secured("SCOPE_ROLE_ADMIN")
-    public ResponseEntity<Avion> createAvion(@RequestBody @Valid AvionDTO avionDTO) {
-        return ResponseEntity.ok(avionService.createDTO(avionDTO));
+    public ResponseEntity<AvionDTO> createAvion(@RequestBody @Valid AvionDTO avionDTO) {
+        Avion savedAvion = avionService.createDTO(avionDTO);
+        if (savedAvion == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(new AvionDTO(savedAvion));
     }
 
     @PutMapping("/")
     @Secured("SCOPE_ROLE_ADMIN")
-    public ResponseEntity<Avion> updateAvion(@RequestBody @Valid AvionDTO avionDTO) {
+    public ResponseEntity<AvionDTO> updateAvion(@RequestBody @Valid AvionDTO avionDTO) {
         Avion avion = avionService.updateDTO(avionDTO);
         if (avion == null) {
             return ResponseEntity.notFound().build();
         } else {
-            return ResponseEntity.ok(avion);
+            return ResponseEntity.ok(new AvionDTO(avion));
         }
     }
 

--- a/server/src/main/java/skybooker/server/controller/ReservationController.java
+++ b/server/src/main/java/skybooker/server/controller/ReservationController.java
@@ -29,27 +29,32 @@ public class ReservationController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Reservation> getReservationById(@PathVariable Long id) {
+    public ResponseEntity<ReservationDTO> getReservationById(@PathVariable Long id) {
         Reservation reservation = reservationService.findById(id);
         if (reservation == null) {
             return ResponseEntity.notFound().build();
         } else {
-            return ResponseEntity.ok(reservation);
+            ReservationDTO reservationDTO = new ReservationDTO(reservation);
+            return ResponseEntity.ok(reservationDTO);
         }
     }
 
     @PostMapping("/")
-    public ResponseEntity<Reservation> createReservation(@RequestBody @Valid ReservationDTO reservationDTO) {
-        return ResponseEntity.ok(reservationService.createDTO(reservationDTO));
+    public ResponseEntity<ReservationDTO> createReservation(@RequestBody @Valid ReservationDTO reservationDTO) {
+        Reservation savedReservation = reservationService.createDTO(reservationDTO);
+        if (savedReservation == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(new ReservationDTO(savedReservation));
     }
 
     @PutMapping("/")
-    public ResponseEntity<Reservation> updateReservation(@RequestBody @Valid ReservationDTO reservationDTO) {
-        Reservation reservation = reservationService.updateDTO(reservationDTO);
-        if (reservation == null) {
+    public ResponseEntity<ReservationDTO> updateReservation(@RequestBody @Valid ReservationDTO reservationDTO) {
+        Reservation updatedReservation = reservationService.updateDTO(reservationDTO);
+        if (updatedReservation == null) {
             return ResponseEntity.notFound().build();
         } else {
-            return ResponseEntity.ok(reservation);
+            return ResponseEntity.ok(new ReservationDTO(updatedReservation));
         }
     }
 

--- a/server/src/main/java/skybooker/server/controller/admin/AdminAvionController.java
+++ b/server/src/main/java/skybooker/server/controller/admin/AdminAvionController.java
@@ -32,7 +32,7 @@ public class AdminAvionController {
         List<Avion> avions = avionService.findAll();
         model.addAttribute("avions", avions);
         model.addAttribute("pageTitle", "Gérer les Avions");
-        return "admin/avion"; // Thymeleaf template for listing avions
+        return "admin/avion";
     }
 
     @GetMapping("/add")
@@ -40,7 +40,7 @@ public class AdminAvionController {
         model.addAttribute("avion", new Avion());
         model.addAttribute("companieAeriennes", companieAerienneService.findAll());
         model.addAttribute("pageTitle", "Ajouter un Avion");
-        return "admin/add-edit-avion"; // Thymeleaf template for add/edit form
+        return "admin/add-edit-avion";
     }
 
     @PostMapping("/save")
@@ -63,7 +63,6 @@ public class AdminAvionController {
             model.addAttribute("avion", avion);
             model.addAttribute("companieAeriennes", companieAerienneService.findAll());
             model.addAttribute("pageTitle", "Modifier un Avion");
-            // The add-edit-avion.html template will display capacities if avion.id != 0
             return "admin/add-edit-avion";
         } else {
             redirectAttributes.addFlashAttribute("errorMessage", "Avion n'existe pas ! :" + id);
@@ -71,13 +70,12 @@ public class AdminAvionController {
         }
     }
 
-    @GetMapping("/details/{id}") // New mapping for viewing details
+    @GetMapping("/details/{id}")
     public String viewAvionDetails(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
-        Avion avion = avionService.findById(id); // Fetch the Avion
+        Avion avion = avionService.findById(id);
         if (avion != null) {
             model.addAttribute("avion", avion);
             model.addAttribute("pageTitle", "Détails de l'Avion");
-            // Return the new template for viewing details
             return "admin/view-avion";
         } else {
             redirectAttributes.addFlashAttribute("errorMessage", "Avion n'existe pas ! :" + id);

--- a/server/src/main/java/skybooker/server/controller/admin/AdminAvionController.java
+++ b/server/src/main/java/skybooker/server/controller/admin/AdminAvionController.java
@@ -1,0 +1,99 @@
+package skybooker.server.controller.admin;
+
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import skybooker.server.entity.Avion;
+import skybooker.server.entity.CompanieAerienne;
+import skybooker.server.service.AvionService;
+import skybooker.server.service.CompanieAerienneService;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin/avion")
+public class AdminAvionController {
+
+    private final AvionService avionService;
+    private final CompanieAerienneService companieAerienneService;
+
+    @Autowired
+    public AdminAvionController(AvionService avionService, CompanieAerienneService companieAerienneService) {
+        this.avionService = avionService;
+        this.companieAerienneService = companieAerienneService;
+    }
+
+    @GetMapping
+    public String listAvions(Model model) {
+        List<Avion> avions = avionService.findAll();
+        model.addAttribute("avions", avions);
+        model.addAttribute("pageTitle", "Gérer les Avions");
+        return "admin/avion"; // Thymeleaf template for listing avions
+    }
+
+    @GetMapping("/add")
+    public String addAvion(Model model) {
+        model.addAttribute("avion", new Avion());
+        model.addAttribute("companieAeriennes", companieAerienneService.findAll());
+        model.addAttribute("pageTitle", "Ajouter un Avion");
+        return "admin/add-edit-avion"; // Thymeleaf template for add/edit form
+    }
+
+    @PostMapping("/save")
+    public String saveAvion(@Valid @ModelAttribute("avion") Avion avion, BindingResult result,
+                            Model model, RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            model.addAttribute("companieAeriennes", companieAerienneService.findAll());
+            model.addAttribute("pageTitle", (avion.getId() == 0 ? "Ajouter" : "Modifier") + " un Avion");
+            return "admin/add-edit-avion";
+        }
+        avionService.create(avion);
+        redirectAttributes.addFlashAttribute("successMessage", "Avion sauvegardé avec succès !");
+        return "redirect:/admin/avion/edit/" + avion.getId();
+    }
+
+    @GetMapping("/edit/{id}")
+    public String editAvion(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
+        Avion avion = avionService.findById(id);
+        if (avion != null) {
+            model.addAttribute("avion", avion);
+            model.addAttribute("companieAeriennes", companieAerienneService.findAll());
+            model.addAttribute("pageTitle", "Modifier un Avion");
+            // The add-edit-avion.html template will display capacities if avion.id != 0
+            return "admin/add-edit-avion";
+        } else {
+            redirectAttributes.addFlashAttribute("errorMessage", "Avion n'existe pas ! :" + id);
+            return "redirect:/admin/avion";
+        }
+    }
+
+    @GetMapping("/details/{id}") // New mapping for viewing details
+    public String viewAvionDetails(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
+        Avion avion = avionService.findById(id); // Fetch the Avion
+        if (avion != null) {
+            model.addAttribute("avion", avion);
+            model.addAttribute("pageTitle", "Détails de l'Avion");
+            // Return the new template for viewing details
+            return "admin/view-avion";
+        } else {
+            redirectAttributes.addFlashAttribute("errorMessage", "Avion n'existe pas ! :" + id);
+            return "redirect:/admin/avion";
+        }
+    }
+
+
+    @GetMapping("/delete/{id}")
+    public String deleteAvion(@PathVariable("id") Long id, RedirectAttributes redirectAttributes) {
+        try {
+            avionService.deleteById(id);
+            redirectAttributes.addFlashAttribute("successMessage", "Avion supprimé avec succès !");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Erreur lors de la suppression de l'Avion :" + e.getMessage());
+        }
+        return "redirect:/admin/avion";
+    }
+}

--- a/server/src/main/java/skybooker/server/controller/admin/AdminBilletController.java
+++ b/server/src/main/java/skybooker/server/controller/admin/AdminBilletController.java
@@ -1,0 +1,94 @@
+package skybooker.server.controller.admin;
+
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import skybooker.server.entity.Billet;
+import skybooker.server.service.BilletService;
+import skybooker.server.service.ClasseService;
+import skybooker.server.service.PassagerService;
+import skybooker.server.service.ReservationService;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin/billet")
+public class AdminBilletController {
+
+    private final BilletService billetService;
+    private final ClasseService classeService;
+    private final PassagerService passagerService;
+    private final ReservationService reservationService;
+
+    @Autowired
+    public AdminBilletController(BilletService billetService, ClasseService classeService, PassagerService passagerService, ReservationService reservationService) {
+        this.billetService = billetService;
+        this.classeService = classeService;
+        this.passagerService = passagerService;
+        this.reservationService = reservationService;
+    }
+
+    @GetMapping
+    public String listBillets(Model model) {
+        List<Billet> billets = billetService.findAll();
+        model.addAttribute("billets", billets);
+        model.addAttribute("pageTitle", "Gérer les Billets");
+        return "admin/billet";
+    }
+
+    @GetMapping("/add")
+    public String addBillet(Model model) {
+        model.addAttribute("billet", new Billet());
+        model.addAttribute("classes", classeService.findAll());
+        model.addAttribute("passagers", passagerService.findAll());
+        model.addAttribute("reservations", reservationService.findAll());
+        model.addAttribute("pageTitle", "Ajouter un Billet");
+        return "admin/add-edit-billet";
+    }
+
+    @PostMapping("/save")
+    public String saveBillet(@Valid @ModelAttribute("billet") Billet billet, BindingResult result,
+                             Model model, RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            model.addAttribute("classes", classeService.findAll());
+            model.addAttribute("passagers", passagerService.findAll());
+            model.addAttribute("reservations", reservationService.findAll());
+            model.addAttribute("pageTitle", (billet.getId() == 0 ? "Ajouter" : "Modifier") + " un Billet");
+            return "admin/add-edit-billet";
+        }
+        billetService.create(billet);
+        redirectAttributes.addFlashAttribute("successMessage", "Billet sauvegardé avec succès !");
+        return "redirect:/admin/billet";
+    }
+
+    @GetMapping("/edit/{id}")
+    public String editBillet(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
+        Billet billet = billetService.findById(id);
+        if (billet != null) {
+            model.addAttribute("billet", billet);
+            model.addAttribute("classes", classeService.findAll());
+            model.addAttribute("passagers", passagerService.findAll());
+            model.addAttribute("reservations", reservationService.findAll());
+            model.addAttribute("pageTitle", "Modifier un Billet");
+            return "admin/add-edit-billet";
+        } else {
+            redirectAttributes.addFlashAttribute("errorMessage", "Billet n'existe pas ! :" + id);
+            return "redirect:/admin/billet";
+        }
+    }
+
+    @GetMapping("/delete/{id}")
+    public String deleteBillet(@PathVariable("id") Long id, RedirectAttributes redirectAttributes) {
+        try {
+            billetService.deleteById(id);
+            redirectAttributes.addFlashAttribute("successMessage", "Billet supprimé avec succès !");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Erreur lors de la suppression du Billet :" + e.getMessage());
+        }
+        return "redirect:/admin/billet";
+    }
+}

--- a/server/src/main/java/skybooker/server/controller/admin/AdminCapaciteController.java
+++ b/server/src/main/java/skybooker/server/controller/admin/AdminCapaciteController.java
@@ -8,21 +8,19 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import skybooker.server.entity.Capacite;
-import skybooker.server.entity.Avion; // Need Avion entity
-import skybooker.server.entity.Classe; // Need Classe entity
+import skybooker.server.entity.Avion;
 import skybooker.server.service.CapaciteService;
-import skybooker.server.service.AvionService; // Need Avion Service for dropdown
-import skybooker.server.service.ClasseService; // Need Classe Service for dropdown
+import skybooker.server.service.AvionService;
+import skybooker.server.service.ClasseService;
 
-import java.util.List;
 
 @Controller
 @RequestMapping("/admin/capacite")
 public class AdminCapaciteController {
 
     private final CapaciteService capaciteService;
-    private final AvionService avionService; // To populate Avion dropdown
-    private final ClasseService classeService; // To populate Classe dropdown
+    private final AvionService avionService;
+    private final ClasseService classeService;
 
     @Autowired
     public AdminCapaciteController(CapaciteService capaciteService, AvionService avionService, ClasseService classeService) {
@@ -31,14 +29,6 @@ public class AdminCapaciteController {
         this.classeService = classeService;
     }
 
-    // We might not need a list all capacities view if managed via Avion
-    // @GetMapping
-    // public String listCapacites(Model model) {
-    //     List<Capacite> capacites = capaciteService.findAll(); // Assuming findAll
-    //     model.addAttribute("capacites", capacites);
-    //     model.addAttribute("pageTitle", "Gérer les Capacités");
-    //     return "admin/capacite"; // Thymeleaf template for listing capacities
-    // }
 
     @GetMapping("/add")
     public String addCapacite(@RequestParam(value = "avionId", required = false) Long avionId, Model model) {
@@ -46,48 +36,46 @@ public class AdminCapaciteController {
         if (avionId != null) {
             Avion avion = avionService.findById(avionId);
             if (avion != null) {
-                capacite.setAvion(avion); // Pre-select the avion if ID is provided
+                capacite.setAvion(avion);
             }
         }
         model.addAttribute("capacite", capacite);
-        model.addAttribute("avions", avionService.findAll()); // For Avion dropdown
-        model.addAttribute("classes", classeService.findAll()); // For Classe dropdown
+        model.addAttribute("avions", avionService.findAll());
+        model.addAttribute("classes", classeService.findAll());
         model.addAttribute("pageTitle", "Ajouter une Capacité");
-        return "admin/add-edit-capacite"; // Thymeleaf template for add/edit form
+        return "admin/add-edit-capacite";
     }
 
     @PostMapping("/save")
     public String saveCapacite(@Valid @ModelAttribute("capacite") Capacite capacite, BindingResult result,
                                Model model, RedirectAttributes redirectAttributes) {
         if (result.hasErrors()) {
-            model.addAttribute("avions", avionService.findAll()); // Repopulate dropdowns on error
+            model.addAttribute("avions", avionService.findAll());
             model.addAttribute("classes", classeService.findAll());
             model.addAttribute("pageTitle", (capacite.getId() == 0 ? "Ajouter" : "Modifier") + " une Capacité");
             return "admin/add-edit-capacite";
         }
-        capaciteService.create(capacite); // Assuming a save method in your service
+        capaciteService.create(capacite);
         redirectAttributes.addFlashAttribute("successMessage", "Capacité sauvegardée avec succès !");
 
-        // Redirect back to the Avion edit page if this capacity is linked to an avion
         if (capacite.getAvion() != null && capacite.getAvion().getId() != 0) {
             return "redirect:/admin/avion/edit/" + capacite.getAvion().getId();
         }
 
-        return "redirect:/admin/capacite"; // Fallback redirect if not linked to an avion
+        return "redirect:/admin/capacite";
     }
 
     @GetMapping("/edit/{id}")
     public String editCapacite(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
-        Capacite capacite = capaciteService.findById(id); // Assuming findById
+        Capacite capacite = capaciteService.findById(id);
         if (capacite != null) {
             model.addAttribute("capacite", capacite);
-            model.addAttribute("avions", avionService.findAll()); // For Avion dropdown
-            model.addAttribute("classes", classeService.findAll()); // For Classe dropdown
+            model.addAttribute("avions", avionService.findAll());
+            model.addAttribute("classes", classeService.findAll());
             model.addAttribute("pageTitle", "Modifier une Capacité");
             return "admin/add-edit-capacite";
         } else {
             redirectAttributes.addFlashAttribute("errorMessage", "Capacité n'existe pas ! :" + id);
-            // Redirect to a relevant page, maybe list of avions or capacities
             return "redirect:/admin/avion";
         }
     }
@@ -101,17 +89,16 @@ public class AdminCapaciteController {
         }
 
         try {
-            capaciteService.deleteById(id); // Assuming deleteById
+            capaciteService.deleteById(id);
             redirectAttributes.addFlashAttribute("successMessage", "Capacité supprimée avec succès !");
         } catch (Exception e) {
             redirectAttributes.addFlashAttribute("errorMessage", "Erreur lors de la suppression de la Capacité :" + e.getMessage());
         }
 
-        // Redirect back to the Avion edit page if this capacity was linked to an avion
         if (avionId != null && avionId != 0) {
             return "redirect:/admin/avion/edit/" + avionId;
         }
 
-        return "redirect:/admin/avion"; // Fallback redirect
+        return "redirect:/admin/avion";
     }
 }

--- a/server/src/main/java/skybooker/server/controller/admin/AdminCapaciteController.java
+++ b/server/src/main/java/skybooker/server/controller/admin/AdminCapaciteController.java
@@ -1,0 +1,117 @@
+package skybooker.server.controller.admin;
+
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import skybooker.server.entity.Capacite;
+import skybooker.server.entity.Avion; // Need Avion entity
+import skybooker.server.entity.Classe; // Need Classe entity
+import skybooker.server.service.CapaciteService;
+import skybooker.server.service.AvionService; // Need Avion Service for dropdown
+import skybooker.server.service.ClasseService; // Need Classe Service for dropdown
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin/capacite")
+public class AdminCapaciteController {
+
+    private final CapaciteService capaciteService;
+    private final AvionService avionService; // To populate Avion dropdown
+    private final ClasseService classeService; // To populate Classe dropdown
+
+    @Autowired
+    public AdminCapaciteController(CapaciteService capaciteService, AvionService avionService, ClasseService classeService) {
+        this.capaciteService = capaciteService;
+        this.avionService = avionService;
+        this.classeService = classeService;
+    }
+
+    // We might not need a list all capacities view if managed via Avion
+    // @GetMapping
+    // public String listCapacites(Model model) {
+    //     List<Capacite> capacites = capaciteService.findAll(); // Assuming findAll
+    //     model.addAttribute("capacites", capacites);
+    //     model.addAttribute("pageTitle", "Gérer les Capacités");
+    //     return "admin/capacite"; // Thymeleaf template for listing capacities
+    // }
+
+    @GetMapping("/add")
+    public String addCapacite(@RequestParam(value = "avionId", required = false) Long avionId, Model model) {
+        Capacite capacite = new Capacite();
+        if (avionId != null) {
+            Avion avion = avionService.findById(avionId);
+            if (avion != null) {
+                capacite.setAvion(avion); // Pre-select the avion if ID is provided
+            }
+        }
+        model.addAttribute("capacite", capacite);
+        model.addAttribute("avions", avionService.findAll()); // For Avion dropdown
+        model.addAttribute("classes", classeService.findAll()); // For Classe dropdown
+        model.addAttribute("pageTitle", "Ajouter une Capacité");
+        return "admin/add-edit-capacite"; // Thymeleaf template for add/edit form
+    }
+
+    @PostMapping("/save")
+    public String saveCapacite(@Valid @ModelAttribute("capacite") Capacite capacite, BindingResult result,
+                               Model model, RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            model.addAttribute("avions", avionService.findAll()); // Repopulate dropdowns on error
+            model.addAttribute("classes", classeService.findAll());
+            model.addAttribute("pageTitle", (capacite.getId() == 0 ? "Ajouter" : "Modifier") + " une Capacité");
+            return "admin/add-edit-capacite";
+        }
+        capaciteService.create(capacite); // Assuming a save method in your service
+        redirectAttributes.addFlashAttribute("successMessage", "Capacité sauvegardée avec succès !");
+
+        // Redirect back to the Avion edit page if this capacity is linked to an avion
+        if (capacite.getAvion() != null && capacite.getAvion().getId() != 0) {
+            return "redirect:/admin/avion/edit/" + capacite.getAvion().getId();
+        }
+
+        return "redirect:/admin/capacite"; // Fallback redirect if not linked to an avion
+    }
+
+    @GetMapping("/edit/{id}")
+    public String editCapacite(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
+        Capacite capacite = capaciteService.findById(id); // Assuming findById
+        if (capacite != null) {
+            model.addAttribute("capacite", capacite);
+            model.addAttribute("avions", avionService.findAll()); // For Avion dropdown
+            model.addAttribute("classes", classeService.findAll()); // For Classe dropdown
+            model.addAttribute("pageTitle", "Modifier une Capacité");
+            return "admin/add-edit-capacite";
+        } else {
+            redirectAttributes.addFlashAttribute("errorMessage", "Capacité n'existe pas ! :" + id);
+            // Redirect to a relevant page, maybe list of avions or capacities
+            return "redirect:/admin/avion";
+        }
+    }
+
+    @GetMapping("/delete/{id}")
+    public String deleteCapacite(@PathVariable("id") Long id, RedirectAttributes redirectAttributes) {
+        Long avionId = null;
+        Capacite capaciteToDelete = capaciteService.findById(id);
+        if (capaciteToDelete != null && capaciteToDelete.getAvion() != null) {
+            avionId = capaciteToDelete.getAvion().getId();
+        }
+
+        try {
+            capaciteService.deleteById(id); // Assuming deleteById
+            redirectAttributes.addFlashAttribute("successMessage", "Capacité supprimée avec succès !");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Erreur lors de la suppression de la Capacité :" + e.getMessage());
+        }
+
+        // Redirect back to the Avion edit page if this capacity was linked to an avion
+        if (avionId != null && avionId != 0) {
+            return "redirect:/admin/avion/edit/" + avionId;
+        }
+
+        return "redirect:/admin/avion"; // Fallback redirect
+    }
+}

--- a/server/src/main/java/skybooker/server/controller/admin/AdminCompanieAerienneController.java
+++ b/server/src/main/java/skybooker/server/controller/admin/AdminCompanieAerienneController.java
@@ -1,0 +1,75 @@
+package skybooker.server.controller.admin;
+
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import skybooker.server.entity.CompanieAerienne;
+import skybooker.server.service.CompanieAerienneService;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin/companie_aerienne")
+public class AdminCompanieAerienneController {
+    private final CompanieAerienneService companieAerienneService;
+
+    @Autowired
+    public AdminCompanieAerienneController(CompanieAerienneService companieAerienneService) {
+        this.companieAerienneService = companieAerienneService;
+    }
+
+    @GetMapping
+    public String listCompanieAeriennes(Model model) {
+        List<CompanieAerienne> companieAerienne = companieAerienneService.findAll();
+        model.addAttribute("companiesAerienne", companieAerienne);
+        model.addAttribute("pageTitle", "Gerer les Companie Aerienne");
+        return "admin/companie_aerienne";
+    }
+
+    @GetMapping("/add")
+    public String addCompanieAerienne(Model model) {
+        model.addAttribute("companieAerienne", new CompanieAerienne());
+        model.addAttribute("pageTitle", "Ajouter une Companie Aerienne");
+        return "admin/add-edit-companie_aerienne";
+    }
+
+    @PostMapping("/save")
+    public String saveCompanieAerienne(@Valid @ModelAttribute("companieAerienne") CompanieAerienne companieAerienne, BindingResult result,
+                                       Model model, RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            model.addAttribute("pageTitle", (companieAerienne.getId() == 0 ? "Ajouter" : "Modifier") +" une Companie Aerienne");
+            return "admin/add-edit-companie_aerienne";
+        }
+        companieAerienneService.create(companieAerienne);
+        redirectAttributes.addFlashAttribute("successMessage", "Companie Aerienne sauvegardé avec succès !");
+        return "redirect:/admin/companie_aerienne";
+    }
+
+    @GetMapping("/edit/{id}")
+    public String editCompanieAerienne(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
+        CompanieAerienne companieAerienne = companieAerienneService.findById(id);
+        if (companieAerienne != null) {
+            model.addAttribute("companieAerienne", companieAerienne);
+            model.addAttribute("pageTitle", "Modifier une Companie Aerienne");
+            return "admin/add-edit-companie_aerienne";
+        } else {
+            redirectAttributes.addFlashAttribute("errorMessage", "Companie Aerienne n'existe ! :" + id);
+            return "redirect:/admin/companie_aerienne";
+        }
+    }
+
+    @GetMapping("/delete/{id}")
+    public String deleteCompanieAerienne(@PathVariable("id") Long id, RedirectAttributes redirectAttributes) {
+        try{
+            companieAerienneService.deleteById(id);
+            redirectAttributes.addFlashAttribute("successMessage", "Companie Aerienne deleted successfully!");
+        } catch (Exception e){
+            redirectAttributes.addFlashAttribute("errorMessage", "Error deleting Companie Aerienne :" + e.getMessage());
+        }
+        return "redirect:/admin/companie_aerienne";
+    }
+}

--- a/server/src/main/java/skybooker/server/controller/admin/AdminVolController.java
+++ b/server/src/main/java/skybooker/server/controller/admin/AdminVolController.java
@@ -1,0 +1,93 @@
+package skybooker.server.controller.admin;
+
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import skybooker.server.entity.Vol;
+import skybooker.server.entity.Aeroport;
+import skybooker.server.entity.Avion;
+import skybooker.server.enums.EtatVol;
+import skybooker.server.service.VolService;
+import skybooker.server.service.AeroportService;
+import skybooker.server.service.AvionService;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/admin/vol")
+public class AdminVolController {
+
+    private final VolService volService;
+    private final AeroportService aeroportService;
+    private final AvionService avionService;
+
+    @Autowired
+    public AdminVolController(VolService volService, AeroportService aeroportService, AvionService avionService) {
+        this.volService = volService;
+        this.aeroportService = aeroportService;
+        this.avionService = avionService;
+    }
+
+    @GetMapping
+    public String listVols(Model model) {
+        List<Vol> vols = volService.findAll();
+        model.addAttribute("vols", vols);
+        model.addAttribute("pageTitle", "Gérer les Vols");
+        return "admin/vol";
+    }
+
+    @GetMapping("/add")
+    public String addVol(Model model) {
+        model.addAttribute("vol", new Vol());
+        model.addAttribute("aeroports", aeroportService.findAll());
+        model.addAttribute("avions", avionService.findAll());
+        model.addAttribute("etatsVol", EtatVol.values());
+        model.addAttribute("pageTitle", "Ajouter un Vol");
+        return "admin/add-edit-vol";
+    }
+
+    @PostMapping("/save")
+    public String saveVol(@Valid @ModelAttribute("vol") Vol vol, BindingResult result,
+                          Model model, RedirectAttributes redirectAttributes) {
+        if (result.hasErrors()) {
+            model.addAttribute("aeroports", aeroportService.findAll());
+            model.addAttribute("avions", avionService.findAll());
+            model.addAttribute("pageTitle", (vol.getId() == 0 ? "Ajouter" : "Modifier") + " un Vol");
+            return "admin/add-edit-vol";
+        }
+        volService.create(vol);
+        redirectAttributes.addFlashAttribute("successMessage", "Vol sauvegardé avec succès !");
+        return "redirect:/admin/vol";
+    }
+
+    @GetMapping("/edit/{id}")
+    public String editVol(@PathVariable("id") Long id, Model model, RedirectAttributes redirectAttributes) {
+        Vol vol = volService.findById(id);
+        if (vol != null) {
+            model.addAttribute("vol", vol);
+            model.addAttribute("aeroports", aeroportService.findAll());
+            model.addAttribute("avions", avionService.findAll());
+            model.addAttribute("etatsVol", EtatVol.values());
+            model.addAttribute("pageTitle", "Modifier un Vol");
+            return "admin/add-edit-vol";
+        } else {
+            redirectAttributes.addFlashAttribute("errorMessage", "Vol n'existe pas ! :" + id);
+            return "redirect:/admin/vol";
+        }
+    }
+
+    @GetMapping("/delete/{id}")
+    public String deleteVol(@PathVariable("id") Long id, RedirectAttributes redirectAttributes) {
+        try {
+            volService.deleteById(id);
+            redirectAttributes.addFlashAttribute("successMessage", "Vol supprimé avec succès !");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Erreur lors de la suppression du Vol :" + e.getMessage());
+        }
+        return "redirect:/admin/vol";
+    }
+}

--- a/server/src/main/java/skybooker/server/entity/Aeroport.java
+++ b/server/src/main/java/skybooker/server/entity/Aeroport.java
@@ -26,16 +26,19 @@ public class Aeroport {
     @ManyToOne(optional = false)
     @JoinColumn(name = "ville_id", nullable = false)
     @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Ville ville;
 
     @JsonIgnore
     @OneToMany(mappedBy = "aeroportArrive", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Vol> volsArrive = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "aeroportDepart", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Vol> volsDepart = new HashSet<>();
 
     public Aeroport(AeroportDTO aeroportDTO) {

--- a/server/src/main/java/skybooker/server/entity/Aeroport.java
+++ b/server/src/main/java/skybooker/server/entity/Aeroport.java
@@ -23,7 +23,7 @@ public class Aeroport {
     private double latitude;
     private double longitude;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "ville_id", nullable = false)
     @ToString.Exclude
     @EqualsAndHashCode.Exclude

--- a/server/src/main/java/skybooker/server/entity/Avion.java
+++ b/server/src/main/java/skybooker/server/entity/Avion.java
@@ -29,13 +29,13 @@ public class Avion {
     private Set<Vol> vols = new HashSet<>();
 
     @JsonIgnore
-    @OneToMany(mappedBy = "avion", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "avion", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private Set<Capacite> capacites = new HashSet<>();
 
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "companie_aerienne_id", nullable = false)
     @ToString.Exclude
     @EqualsAndHashCode.Exclude

--- a/server/src/main/java/skybooker/server/entity/Avion.java
+++ b/server/src/main/java/skybooker/server/entity/Avion.java
@@ -2,9 +2,7 @@ package skybooker.server.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import skybooker.server.DTO.AvionDTO;
 
 import java.util.HashSet;
@@ -26,15 +24,21 @@ public class Avion {
 
     @JsonIgnore
     @OneToMany(mappedBy = "avion", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Vol> vols = new HashSet<>();
 
     @JsonIgnore
     @OneToMany(mappedBy = "avion", cascade = CascadeType.ALL)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Capacite> capacites = new HashSet<>();
 
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "companie_aerienne_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private CompanieAerienne companieAerienne;
 
     /**

--- a/server/src/main/java/skybooker/server/entity/Billet.java
+++ b/server/src/main/java/skybooker/server/entity/Billet.java
@@ -2,9 +2,7 @@ package skybooker.server.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import skybooker.server.DTO.BilletDTO;
 
 @Data
@@ -18,16 +16,22 @@ public class Billet {
     private long id;
     private int siege;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "classe_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Classe classe;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "passager_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Passager passager;
 
     @JsonIgnore
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Reservation reservation;
 }

--- a/server/src/main/java/skybooker/server/entity/Capacite.java
+++ b/server/src/main/java/skybooker/server/entity/Capacite.java
@@ -2,9 +2,7 @@ package skybooker.server.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import skybooker.server.DTO.CapaciteDTO;
 
 @AllArgsConstructor
@@ -25,6 +23,7 @@ public class Capacite {
     @JsonIgnore
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "avion_id", nullable = false)
+    @EqualsAndHashCode.Exclude
     private Avion avion;
 
     @ManyToOne

--- a/server/src/main/java/skybooker/server/entity/Capacite.java
+++ b/server/src/main/java/skybooker/server/entity/Capacite.java
@@ -23,11 +23,14 @@ public class Capacite {
     @JsonIgnore
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "avion_id", nullable = false)
+    @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private Avion avion;
 
     @ManyToOne
     @JoinColumn(name = "classe_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Classe classe;
 
     public Capacite(CapaciteDTO capaciteDTO) {

--- a/server/src/main/java/skybooker/server/entity/Classe.java
+++ b/server/src/main/java/skybooker/server/entity/Classe.java
@@ -21,6 +21,7 @@ public class Classe {
 
     @JsonIgnore
     @OneToMany(mappedBy = "classe", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private Set<Billet> billets = new HashSet<>();
 }

--- a/server/src/main/java/skybooker/server/entity/Classe.java
+++ b/server/src/main/java/skybooker/server/entity/Classe.java
@@ -2,9 +2,7 @@ package skybooker.server.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -23,5 +21,6 @@ public class Classe {
 
     @JsonIgnore
     @OneToMany(mappedBy = "classe", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @EqualsAndHashCode.Exclude
     private Set<Billet> billets = new HashSet<>();
 }

--- a/server/src/main/java/skybooker/server/entity/Client.java
+++ b/server/src/main/java/skybooker/server/entity/Client.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 import skybooker.server.DTO.ClientDTO;
 
@@ -34,14 +36,20 @@ public class Client{
     @NotNull
     private String adresse;
 
-    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "client", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Reservation> reservations = new HashSet<>();
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Passager passager;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Role role;
 
 

--- a/server/src/main/java/skybooker/server/entity/Client.java
+++ b/server/src/main/java/skybooker/server/entity/Client.java
@@ -43,9 +43,6 @@ public class Client{
     private Set<Reservation> reservations = new HashSet<>();
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private Set<Reservation> reservations = new HashSet<>();
-
-    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Passager passager;
 
     @ManyToOne(optional = false, fetch = FetchType.LAZY)

--- a/server/src/main/java/skybooker/server/entity/CompanieAerienne.java
+++ b/server/src/main/java/skybooker/server/entity/CompanieAerienne.java
@@ -2,9 +2,7 @@ package skybooker.server.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import skybooker.server.DTO.CompanieAerienneDTO;
 
 import java.util.HashSet;
@@ -25,6 +23,8 @@ public class CompanieAerienne {
 
     @JsonIgnore
     @OneToMany(mappedBy = "companieAerienne", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     private Set<Avion> avions = new HashSet<>();
 
     public CompanieAerienne(CompanieAerienneDTO companieAerienneDTO) {

--- a/server/src/main/java/skybooker/server/entity/Passager.java
+++ b/server/src/main/java/skybooker/server/entity/Passager.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import skybooker.server.DTO.PassagerDTO;
 import skybooker.server.service.CategorieService;
 
@@ -38,7 +36,9 @@ public class Passager {
     @Min(0)
     private int age;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     @JoinColumn(name = "categorie_id", nullable = false)
     private Categorie categorie;
 

--- a/server/src/main/java/skybooker/server/entity/Reservation.java
+++ b/server/src/main/java/skybooker/server/entity/Reservation.java
@@ -2,9 +2,7 @@ package skybooker.server.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.Min;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import skybooker.server.DTO.ReservationDTO;
 import skybooker.server.enums.EtatReservation;
@@ -30,19 +28,25 @@ public class Reservation {
     private double prixTotal;
 
     @JsonIgnore
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "client_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Client client;
 
     @Column(name = "reserved_at")
     @CreationTimestamp
     private LocalDateTime reservedAt;
 
-    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Billet> billets = new HashSet<>();
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "vol_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Vol vol;
 
     public Reservation(ReservationDTO reservationDTO) {

--- a/server/src/main/java/skybooker/server/entity/Ville.java
+++ b/server/src/main/java/skybooker/server/entity/Ville.java
@@ -23,6 +23,7 @@ public class Ville {
     @JsonIgnore
     @OneToMany(mappedBy = "ville", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Set<Aeroport> aeroports = new HashSet<>();
 
     public Ville(VilleDTO villeDTO) {

--- a/server/src/main/java/skybooker/server/entity/Vol.java
+++ b/server/src/main/java/skybooker/server/entity/Vol.java
@@ -25,24 +25,26 @@ public class Vol {
     private Time heureDepart;
     private Date dateArrive;
     private Time heureArrive;
+
+    @Enumerated(EnumType.ORDINAL) // Map enum to integer ordinal in DB
     private EtatVol etat;
 
     @Min(0)
     private double prix;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "aeroport_depart_id", nullable = false)
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private Aeroport aeroportDepart;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "aeroport_arrive_id", nullable = false)
     @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private Aeroport aeroportArrive;
 
-    @ManyToOne(optional = false)
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "avion_id", nullable = false)
     @ToString.Exclude
     @EqualsAndHashCode.Exclude

--- a/server/src/main/java/skybooker/server/entity/Vol.java
+++ b/server/src/main/java/skybooker/server/entity/Vol.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 import skybooker.server.DTO.VolDTO;
 import skybooker.server.enums.EtatVol;
 import java.sql.Time;
@@ -22,12 +23,17 @@ public class Vol {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date dateDepart;
+
     private Time heureDepart;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private Date dateArrive;
+
     private Time heureArrive;
 
-    @Enumerated(EnumType.ORDINAL) // Map enum to integer ordinal in DB
+    @Enumerated(EnumType.STRING) // Map enum to String in DB
     private EtatVol etat;
 
     @Min(0)

--- a/server/src/main/java/skybooker/server/entity/Vol.java
+++ b/server/src/main/java/skybooker/server/entity/Vol.java
@@ -32,19 +32,25 @@ public class Vol {
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "aeroport_depart_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Aeroport aeroportDepart;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "aeroport_arrive_id", nullable = false)
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
     private Aeroport aeroportArrive;
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "avion_id", nullable = false)
+    @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private Avion avion;
 
     @JsonIgnore
     @OneToMany(mappedBy = "vol", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
     @EqualsAndHashCode.Exclude
     private Set<Reservation> reservations = new HashSet<>();
 

--- a/server/src/main/java/skybooker/server/entity/Vol.java
+++ b/server/src/main/java/skybooker/server/entity/Vol.java
@@ -3,9 +3,7 @@ package skybooker.server.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import skybooker.server.DTO.VolDTO;
 import skybooker.server.enums.EtatVol;
 import java.sql.Time;
@@ -42,10 +40,12 @@ public class Vol {
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "avion_id", nullable = false)
+    @EqualsAndHashCode.Exclude
     private Avion avion;
 
     @JsonIgnore
     @OneToMany(mappedBy = "vol", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @EqualsAndHashCode.Exclude
     private Set<Reservation> reservations = new HashSet<>();
 
     public Vol(VolDTO volDTO) {

--- a/server/src/main/resources/data/mock_data.sql
+++ b/server/src/main/resources/data/mock_data.sql
@@ -169,125 +169,125 @@ INSERT INTO capacites (borne_inf, borne_sup, capacite, avion_id, classe_id) VALU
 
 -- Paris (CDG) to London (LHR)
 INSERT INTO vols (date_depart , date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-20', '2025-05-20', '07:30:00', '08:30:00', 0, 250.00,
+('2025-05-20', '2025-05-20', '07:30:00', '08:30:00', 'SCHEDULED', 250.00,
 (SELECT id FROM aeroports WHERE iata_code = 'CDG'),
 (SELECT id FROM aeroports WHERE iata_code = 'LHR'),
 (SELECT id FROM avions WHERE model = 'Airbus A320' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF'))),
 
-('2025-05-20', '2025-05-20', '14:00:00', '15:00:00', 0, 270.00,
+('2025-05-20', '2025-05-20', '14:00:00', '15:00:00', 'SCHEDULED', 270.00,
 (SELECT id FROM aeroports WHERE iata_code = 'CDG'),
 (SELECT id FROM aeroports WHERE iata_code = 'LHR'),
 (SELECT id FROM avions WHERE model = 'Airbus A320' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF'))),
 
-('2025-05-21', '2025-05-21', '08:15:00', '09:15:00', 0, 250.00,
+('2025-05-21', '2025-05-21', '08:15:00', '09:15:00', 'SCHEDULED', 250.00,
 (SELECT id FROM aeroports WHERE iata_code = 'LHR'),
 (SELECT id FROM aeroports WHERE iata_code = 'CDG'),
 (SELECT id FROM avions WHERE model = 'Boeing 747-400' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'BA')));
 
 -- Paris (CDG) to New York (JFK) - Arrival time is local NY time
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-20', '2025-05-20', '10:30:00', '13:30:00', 0, 1200.00, -- Departure 10:30 Paris, Arrival 13:30 NY time
+('2025-05-20', '2025-05-20', '10:30:00', '13:30:00', 'SCHEDULED', 1200.00, -- Departure 10:30 Paris, Arrival 13:30 NY time
 (SELECT id FROM aeroports WHERE iata_code = 'CDG'),
 (SELECT id FROM aeroports WHERE iata_code = 'JFK'),
 (SELECT id FROM avions WHERE model = 'Boeing 777-300ER' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF'))),
 
-('2025-05-22', '2025-05-23', '18:00:00', '07:00:00', 0, 1350.00, -- Departure 18:00 NY, Arrival 07:00 next day Paris time
+('2025-05-22', '2025-05-23', '18:00:00', '07:00:00', 'SCHEDULED', 1350.00, -- Departure 18:00 NY, Arrival 07:00 next day Paris time
 (SELECT id FROM aeroports WHERE iata_code = 'JFK'),
 (SELECT id FROM aeroports WHERE iata_code = 'CDG'),
 (SELECT id FROM avions WHERE model = 'Boeing 777-300ER' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF')));
 
 -- Dubai (DXB) to Tokyo (HND) - Arrival time is local Tokyo time
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-21', '2025-05-22', '23:45:00', '15:30:00', 0, 1800.00, -- Departure 23:45 Dubai, Arrival 15:30 next day Tokyo
+('2025-05-21', '2025-05-22', '23:45:00', '15:30:00', 'BOARDING', 1800.00, -- Departure 23:45 Dubai, Arrival 15:30 next day Tokyo
 (SELECT id FROM aeroports WHERE iata_code = 'DXB'),
 (SELECT id FROM aeroports WHERE iata_code = 'HND'),
 (SELECT id FROM avions WHERE model = 'Airbus A380-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'EK'))),
 
-('2025-05-24', '2025-05-24', '01:30:00', '17:15:00', 0, 1750.00, -- Departure 01:30 Tokyo, Arrival 17:15 same day Dubai (after time zone conversion and flight)
+('2025-05-24', '2025-05-24', '01:30:00', '17:15:00', 'BOARDING', 1750.00, -- Departure 01:30 Tokyo, Arrival 17:15 same day Dubai (after time zone conversion and flight)
 (SELECT id FROM aeroports WHERE iata_code = 'HND'),
 (SELECT id FROM aeroports WHERE iata_code = 'DXB'),
 (SELECT id FROM avions WHERE model = 'Airbus A380-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'EK')));
 
 -- London (LHR) to Berlin (BER)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-22', '2025-05-22', '06:45:00', '09:30:00', 0, 320.00,
+('2025-05-22', '2025-05-22', '06:45:00', '09:30:00', 'BOARDING', 320.00,
 (SELECT id FROM aeroports WHERE iata_code = 'LHR'),
 (SELECT id FROM aeroports WHERE iata_code = 'BER'),
 (SELECT id FROM avions WHERE model = 'Airbus A321neo' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'LH'))),
 
-('2025-05-23', '2025-05-23', '17:15:00', '20:00:00', 0, 290.00,
+('2025-05-23', '2025-05-23', '17:15:00', '20:00:00', 'CANCELLED', 290.00,
 (SELECT id FROM aeroports WHERE iata_code = 'BER'),
 (SELECT id FROM aeroports WHERE iata_code = 'LHR'),
 (SELECT id FROM avions WHERE model = 'Airbus A321neo' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'LH')));
 
 -- New York (JFK) to Rome (FCO)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-25', '2025-05-26', '19:20:00', '10:15:00', 0, 1450.00, -- Dep 19:20 NY, Arr 10:15 next day Rome
+('2025-05-25', '2025-05-26', '19:20:00', '10:15:00', 'CANCELLED', 1450.00, -- Dep 19:20 NY, Arr 10:15 next day Rome
 (SELECT id FROM aeroports WHERE iata_code = 'JFK'),
 (SELECT id FROM aeroports WHERE iata_code = 'FCO'),
 (SELECT id FROM avions WHERE model = 'Boeing 787-9 Dreamliner' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AA'))),
 
-('2025-05-28', '2025-05-28', '12:10:00', '17:05:00', 0, 1400.00, -- Dep 12:10 Rome, Arr 17:05 NY (after time zone & flight)
+('2025-05-28', '2025-05-28', '12:10:00', '17:05:00', 'CANCELLED', 1400.00, -- Dep 12:10 Rome, Arr 17:05 NY (after time zone & flight)
 (SELECT id FROM aeroports WHERE iata_code = 'FCO'),
 (SELECT id FROM aeroports WHERE iata_code = 'JFK'),
 (SELECT id FROM avions WHERE model = 'Boeing 787-9 Dreamliner' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AA')));
 
 -- Madrid (MAD) to Casablanca (CMN)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-21', '2025-05-21', '11:40:00', '13:20:00', 0, 410.00,
+('2025-05-21', '2025-05-21', '11:40:00', '13:20:00', 'DELAYED', 410.00,
 (SELECT id FROM aeroports WHERE iata_code = 'MAD'),
 (SELECT id FROM aeroports WHERE iata_code = 'CMN'),
 (SELECT id FROM avions WHERE model = 'Airbus A350-900' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'QR'))),
 
-('2025-05-22', '2025-05-22', '15:30:00', '17:10:00', 0, 395.00,
+('2025-05-22', '2025-05-22', '15:30:00', '17:10:00', 'DELAYED', 395.00,
 (SELECT id FROM aeroports WHERE iata_code = 'CMN'),
 (SELECT id FROM aeroports WHERE iata_code = 'MAD'),
 (SELECT id FROM avions WHERE model = 'Airbus A350-900' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'QR')));
 
 -- Singapore (SIN) to Sydney (SYD)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-24', '2025-05-25', '21:15:00', '07:45:00', 0, 980.00,
+('2025-05-24', '2025-05-25', '21:15:00', '07:45:00', 'SCHEDULED', 980.00,
 (SELECT id FROM aeroports WHERE iata_code = 'SIN'),
 (SELECT id FROM aeroports WHERE iata_code = 'SYD'),
 (SELECT id FROM avions WHERE model = 'Boeing 737-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'SQ'))),
 
-('2025-05-26', '2025-05-26', '09:20:00', '17:50:00', 0, 950.00, -- Dep SYD, Arr SIN same day
+('2025-05-26', '2025-05-26', '09:20:00', '17:50:00', 'SCHEDULED', 950.00, -- Dep SYD, Arr SIN same day
 (SELECT id FROM aeroports WHERE iata_code = 'SYD'),
 (SELECT id FROM aeroports WHERE iata_code = 'SIN'),
 (SELECT id FROM avions WHERE model = 'Boeing 737-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'SQ')));
 
 -- Cairo (CAI) to Moscow (SVO)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-23', '2025-05-23', '08:30:00', '14:15:00', 0, 660.00,
+('2025-05-23', '2025-05-23', '08:30:00', '14:15:00', 'SCHEDULED', 660.00,
 (SELECT id FROM aeroports WHERE iata_code = 'CAI'),
 (SELECT id FROM aeroports WHERE iata_code = 'SVO'),
 (SELECT id FROM avions WHERE model = 'Airbus A330-300' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'LH'))),
 
-('2025-05-25', '2025-05-25', '16:40:00', '22:25:00', 0, 680.00,
+('2025-05-25', '2025-05-25', '16:40:00', '22:25:00', 'SCHEDULED', 680.00,
 (SELECT id FROM aeroports WHERE iata_code = 'SVO'),
 (SELECT id FROM aeroports WHERE iata_code = 'CAI'),
 (SELECT id FROM avions WHERE model = 'Airbus A330-300' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'LH')));
 
 -- Rio de Janeiro (GIG) to Madrid (MAD)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-22', '2025-05-23', '23:10:00', '14:30:00', 0, 1650.00, -- Dep GIG, Arr MAD next day
+('2025-05-22', '2025-05-23', '23:10:00', '14:30:00', 'SCHEDULED', 1650.00, -- Dep GIG, Arr MAD next day
 (SELECT id FROM aeroports WHERE iata_code = 'GIG'),
 (SELECT id FROM aeroports WHERE iata_code = 'MAD'),
 (SELECT id FROM avions WHERE model = 'Boeing 777-300ER' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF'))),
 
-('2025-05-26', '2025-05-27', '16:45:00', '08:05:00', 0, 1620.00, -- Dep MAD, Arr GIG next day
+('2025-05-26', '2025-05-27', '16:45:00', '08:05:00', 'SCHEDULED', 1620.00, -- Dep MAD, Arr GIG next day
 (SELECT id FROM aeroports WHERE iata_code = 'MAD'),
 (SELECT id FROM aeroports WHERE iata_code = 'GIG'),
 (SELECT id FROM avions WHERE model = 'Boeing 777-300ER' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF')));
 
 -- Bangkok (BKK) to Tokyo (HND)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-20', '2025-05-20', '10:15:00', '18:40:00', 0, 890.00,
+('2025-05-20', '2025-05-20', '10:15:00', '18:40:00', 'SCHEDULED', 890.00,
 (SELECT id FROM aeroports WHERE iata_code = 'BKK'),
 (SELECT id FROM aeroports WHERE iata_code = 'HND'),
 (SELECT id FROM avions WHERE model = 'Boeing 787-9 Dreamliner' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AA'))),
 
-('2025-05-23', '2025-05-23', '13:50:00', '22:15:00', 0, 860.00,
+('2025-05-23', '2025-05-23', '13:50:00', '22:15:00', 'SCHEDULED', 860.00,
 (SELECT id FROM aeroports WHERE iata_code = 'HND'),
 (SELECT id FROM aeroports WHERE iata_code = 'BKK'),
 (SELECT id FROM avions WHERE model = 'Boeing 787-9 Dreamliner' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AA')));
@@ -295,60 +295,60 @@ INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, pr
 -- Add more flights for more diversity
 -- Paris (ORY) to Madrid (MAD)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-26', '2025-05-26', '09:15:00', '11:30:00', 0, 280.00,
+('2025-05-26', '2025-05-26', '09:15:00', '11:30:00', 'SCHEDULED', 280.00,
 (SELECT id FROM aeroports WHERE iata_code = 'ORY'),
 (SELECT id FROM aeroports WHERE iata_code = 'MAD'),
 (SELECT id FROM avions WHERE model = 'Airbus A320' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF'))),
 
-('2025-05-26', '2025-05-26', '16:20:00', '18:35:00', 0, 310.00,
+('2025-05-26', '2025-05-26', '16:20:00', '18:35:00', 'SCHEDULED', 310.00,
 (SELECT id FROM aeroports WHERE iata_code = 'MAD'),
 (SELECT id FROM aeroports WHERE iata_code = 'ORY'),
 (SELECT id FROM avions WHERE model = 'Airbus A320' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AF')));
 
 -- Tokyo (HND) to Singapore (SIN)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-27', '2025-05-27', '11:05:00', '17:40:00', 0, 920.00,
+('2025-05-27', '2025-05-27', '11:05:00', '17:40:00', 'SCHEDULED', 920.00,
 (SELECT id FROM aeroports WHERE iata_code = 'HND'),
 (SELECT id FROM aeroports WHERE iata_code = 'SIN'),
 (SELECT id FROM avions WHERE model = 'Boeing 737-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'SQ'))), 
 
-('2025-05-29', '2025-05-29', '09:30:00', '16:05:00', 0, 890.00,
+('2025-05-29', '2025-05-29', '09:30:00', '16:05:00', 'SCHEDULED', 890.00,
 (SELECT id FROM aeroports WHERE iata_code = 'SIN'),
 (SELECT id FROM aeroports WHERE iata_code = 'HND'),
 (SELECT id FROM avions WHERE model = 'Boeing 737-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'SQ'))); 
 
 -- London (LHR) to Dubai (DXB)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-28', '2025-05-29', '22:10:00', '08:45:00', 0, 850.00, -- Dep LHR, Arr DXB next day
+('2025-05-28', '2025-05-29', '22:10:00', '08:45:00', 'SCHEDULED', 850.00, -- Dep LHR, Arr DXB next day
 (SELECT id FROM aeroports WHERE iata_code = 'LHR'),
 (SELECT id FROM aeroports WHERE iata_code = 'DXB'),
 (SELECT id FROM avions WHERE model = 'Boeing 747-400' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'BA'))), 
 
-('2025-05-30', '2025-05-30', '01:30:00', '06:05:00', 0, 820.00, -- Dep DXB, Arr LHR same day
+('2025-05-30', '2025-05-30', '01:30:00', '06:05:00', 'SCHEDULED', 820.00, -- Dep DXB, Arr LHR same day
 (SELECT id FROM aeroports WHERE iata_code = 'DXB'),
 (SELECT id FROM aeroports WHERE iata_code = 'LHR'),
 (SELECT id FROM avions WHERE model = 'Boeing 747-400' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'BA'))); 
 
 -- New York (JFK) to Los Angeles (LAX)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-25', '2025-05-25', '07:20:00', '11:05:00', 0, 680.00, 
+('2025-05-25', '2025-05-25', '07:20:00', '11:05:00', 'SCHEDULED', 680.00,
 (SELECT id FROM aeroports WHERE iata_code = 'JFK'),
 (SELECT id FROM aeroports WHERE iata_code = 'LAX'),
 (SELECT id FROM avions WHERE model = 'Boeing 767-300ER' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AA'))),
 
-('2025-05-27', '2025-05-27', '14:45:00', '22:30:00', 0, 650.00, 
+('2025-05-27', '2025-05-27', '14:45:00', '22:30:00', 'SCHEDULED', 650.00,
 (SELECT id FROM aeroports WHERE iata_code = 'LAX'),
 (SELECT id FROM aeroports WHERE iata_code = 'JFK'),
 (SELECT id FROM avions WHERE model = 'Boeing 767-300ER' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'AA')));
 
 -- Sydney (SYD) to Bangkok (BKK)
 INSERT INTO vols (date_depart, date_arrive, heure_depart, heure_arrive, etat, prix, aeroport_depart_id, aeroport_arrive_id, avion_id) VALUES
-('2025-05-26', '2025-05-27', '20:15:00', '03:50:00', 0, 1120.00, -- Dep SYD, Arr BKK next day
+('2025-05-26', '2025-05-27', '20:15:00', '03:50:00', 'SCHEDULED', 1120.00, -- Dep SYD, Arr BKK next day
 (SELECT id FROM aeroports WHERE iata_code = 'SYD'),
 (SELECT id FROM aeroports WHERE iata_code = 'BKK'),
 (SELECT id FROM avions WHERE model = 'Boeing 737-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'SQ'))),
 
-('2025-05-28', '2025-05-28', '01:40:00', '15:15:00', 0, 1080.00, -- Dep BKK, Arr SYD same day
+('2025-05-28', '2025-05-28', '01:40:00', '15:15:00', 'SCHEDULED', 1080.00, -- Dep BKK, Arr SYD same day
 (SELECT id FROM aeroports WHERE iata_code = 'BKK'),
 (SELECT id FROM aeroports WHERE iata_code = 'SYD'),
 (SELECT id FROM avions WHERE model = 'Boeing 737-800' AND companie_aerienne_id = (SELECT id FROM companie_aerienne WHERE iata_code = 'SQ'))); 

--- a/server/src/main/resources/templates/admin/add-edit-avion.html
+++ b/server/src/main/resources/templates/admin/add-edit-avion.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+  <h1 th:text="${pageTitle}"></h1>
+
+  <form th:action="@{/admin/avion/save}" th:object="${avion}" method="post">
+    <input type="hidden" th:field="*{id}" />
+
+    <div class="mb-3">
+      <label for="model" class="form-label">Modèle:</label>
+      <input type="text" th:field="*{model}" id="model" class="form-control" />
+      <div th:if="${#fields.hasErrors('model')}" th:errors="*{model}" class="text-danger">Modèle Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="iataCode" class="form-label">IATA CODE:</label>
+      <input type="text" th:field="*{iataCode}" id="iataCode" class="form-control" />
+      <div th:if="${#fields.hasErrors('iataCode')}" th:errors="*{iataCode}" class="text-danger">IATA Code Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="icaoCode" class="form-label">ICAO CODE:</label>
+      <input type="text" th:field="*{icaoCode}" id="icaoCode" class="form-control" />
+      <div th:if="${#fields.hasErrors('icaoCode')}" th:errors="*{icaoCode}" class="text-danger">ICAO Code Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="maxDistance" class="form-label">Distance Maximale:</label>
+      <input type="number" th:field="*{maxDistance}" id="maxDistance" class="form-control" step="0.01" />
+      <div th:if="${#fields.hasErrors('maxDistance')}" th:errors="*{maxDistance}" class="text-danger">Distance Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="companieAerienne" class="form-label">Compagnie Aérienne:</label>
+      <select th:field="*{companieAerienne}" id="companieAerienne" class="form-control">
+        <option th:each="company : ${companieAeriennes}"
+                th:value="${company.id}"
+                th:text="${company.nom}"
+                th:selected="${avion.companieAerienne != null && avion.companieAerienne.id == company.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('companieAerienne')}" th:errors="*{companieAerienne}" class="text-danger">Compagnie Error</div>
+    </div>
+
+    <button type="submit" class="btn btn-success">Sauvegarder Avion</button>
+    <a th:href="@{/admin/avion}" class="btn btn-secondary">Annuler</a>
+  </form>
+
+  <div th:if="${avion.id != 0}" class="mt-5">
+    <h2>Capacités</h2>
+    <a th:href="@{/admin/capacite/add(avionId=${avion.id})}" class="btn btn-primary mb-3">Ajouter une nouvelle Capacité pour cet Avion</a>
+
+    <table class="table table-striped table-bordered">
+      <thead class="table-dark">
+      <tr>
+        <th>ID</th>
+        <th>Borne Inf</th>
+        <th>Borne Sup</th>
+        <th>Capacité</th>
+        <th>Classe</th>
+        <th>Actions</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr th:each="capacite : ${avion.capacites}"> <td th:text="${capacite.id}"></td>
+        <td th:text="${capacite.borneInf}"></td>
+        <td th:text="${capacite.borneSup}"></td>
+        <td th:text="${capacite.capacite}"></td>
+        <td th:text="${capacite.classe.nom}"></td> <td>
+          <a th:href="@{/admin/capacite/edit/{id}(id=${capacite.id})}" class="btn btn-sm btn-warning">Modifier</a>
+          <a th:href="@{/admin/capacite/delete/{id}(id=${capacite.id})}"
+             onclick="return confirm('Êtes-vous sûr de vouloir supprimer cette capacité ?')"
+             class="btn btn-sm btn-danger">Supprimer</a>
+        </td>
+      </tr>
+      <tr th:if="${#lists.isEmpty(avion.capacites)}">
+        <td colspan="6" class="text-center">Aucune capacité trouvée pour cet avion.</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/add-edit-billet.html
+++ b/server/src/main/resources/templates/admin/add-edit-billet.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+  <h1 th:text="${pageTitle}"></h1>
+
+  <form th:action="@{/admin/billet/save}" th:object="${billet}" method="post">
+    <input type="hidden" th:field="*{id}" />
+
+    <div class="mb-3">
+      <label for="siege" class="form-label">Siège:</label>
+      <input type="number" th:field="*{siege}" id="siege" class="form-control" />
+      <div th:if="${#fields.hasErrors('siege')}" th:errors="*{siege}" class="text-danger">Siège Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="classe" class="form-label">Classe:</label>
+      <select th:field="*{classe}" id="classe" class="form-control">
+        <option th:each="classeOption : ${classes}"
+                th:value="${classeOption.id}"
+                th:text="${classeOption.nom}"
+                th:selected="${billet.classe != null && billet.classe.id == classeOption.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('classe')}" th:errors="*{classe}" class="text-danger">Classe Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="passager" class="form-label">Passager:</label>
+      <select th:field="*{passager}" id="passager" class="form-control">
+        <option th:each="passagerOption : ${passagers}"
+                th:value="${passagerOption.id}"
+                th:text="${passagerOption.prenom + ' ' + passagerOption.nom + ' (' + passagerOption.CIN + ')'}"
+                th:selected="${billet.passager != null && billet.passager.id == passagerOption.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('passager')}" th:errors="*{passager}" class="text-danger">Passager Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="reservation" class="form-label">Réservation:</label>
+      <select th:field="*{reservation}" id="reservation" class="form-control">
+        <option th:each="reservationOption : ${reservations}"
+                th:value="${reservationOption.id}"
+                th:text="${'ID: ' + reservationOption.id + ' - Client: ' + (reservationOption.client != null ? reservationOption.client.email : 'N/A') + ' - Vol ID: ' + (reservationOption.vol != null ? reservationOption.vol.id : 'N/A')}"
+                th:selected="${billet.reservation != null && billet.reservation.id == reservationOption.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('reservation')}" th:errors="*{reservation}" class="text-danger">Réservation Error</div>
+    </div>
+
+
+    <button type="submit" class="btn btn-success">Sauvegarder Billet</button>
+    <a th:href="@{/admin/billet}" class="btn btn-secondary">Annuler</a>
+  </form>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/add-edit-capacite.html
+++ b/server/src/main/resources/templates/admin/add-edit-capacite.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+  <h1 th:text="${pageTitle}"></h1>
+
+  <form th:action="@{/admin/capacite/save}" th:object="${capacite}" method="post">
+    <input type="hidden" th:field="*{id}" />
+
+    <div class="mb-3">
+      <label for="avion" class="form-label">Avion:</label>
+      <select th:field="*{avion}" id="avion" class="form-control">
+        <option th:each="avionOption : ${avions}"
+                th:value="${avionOption.id}"
+                th:text="${avionOption.model + ' (' + avionOption.iataCode + ')'}"
+                th:selected="${capacite.avion != null && capacite.avion.id == avionOption.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('avion')}" th:errors="*{avion}" class="text-danger">Avion Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="classe" class="form-label">Classe:</label>
+      <select th:field="*{classe}" id="classe" class="form-control">
+        <option th:each="classeOption : ${classes}"
+                th:value="${classeOption.id}"
+                th:text="${classeOption.nom}"
+                th:selected="${capacite.classe != null && capacite.classe.id == classeOption.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('classe')}" th:errors="*{classe}" class="text-danger">Classe Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="borneInf" class="form-label">Borne Inf (Sièges):</label>
+      <input type="number" th:field="*{borneInf}" id="borneInf" class="form-control" />
+      <div th:if="${#fields.hasErrors('borneInf')}" th:errors="*{borneInf}" class="text-danger">Borne Inf Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="borneSup" class="form-label">Borne Sup (Sièges):</label>
+      <input type="number" th:field="*{borneSup}" id="borneSup" class="form-control" />
+      <div th:if="${#fields.hasErrors('borneSup')}" th:errors="*{borneSup}" class="text-danger">Borne Sup Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="capacite" class="form-label">Capacité (Nombre de sièges):</label>
+      <input type="number" th:field="*{capacite}" id="capacite" class="form-control" />
+      <div th:if="${#fields.hasErrors('capacite')}" th:errors="*{capacite}" class="text-danger">Capacité Error</div>
+    </div>
+
+    <button type="submit" class="btn btn-success">Sauvegarder Capacité</button>
+    <a th:href="@{/admin/avion}" class="btn btn-secondary">Annuler</a> </form>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/add-edit-companie_aerienne.html
+++ b/server/src/main/resources/templates/admin/add-edit-companie_aerienne.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+  <h1 th:text="${pageTitle}">Add/Edit Companie Aeriennes</h1>
+
+  <form th:action="@{/admin/companie_aerienne/save}" th:object="${companieAerienne}" method="post">
+    <input type="hidden" th:field="*{id}" />
+
+    <div class="mb-3">
+      <label for="nom" class="form-label">Companie Aeriennes Name:</label>
+      <input type="text" th:field="*{nom}" id="nom" class="form-control" /> <div th:if="${#fields.hasErrors('nom')}" th:errors="*{nom}" class="text-danger">Name Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="nom" class="form-label">IATA CODE:</label>
+      <input type="text" th:field="*{iataCode}" id="iataCode" class="form-control" /> <div th:if="${#fields.hasErrors('iataCode')}" th:errors="*{iataCode}" class="text-danger">Name Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="nom" class="form-label">ICAO CODE:</label>
+      <input type="text" th:field="*{icaoCode}" id="icaoCode" class="form-control" /> <div th:if="${#fields.hasErrors('icaoCode')}" th:errors="*{icaoCode}" class="text-danger">Name Error</div>
+    </div>
+
+
+    <button type="submit" class="btn btn-success">Save Companie Aeriennes</button>
+    <a th:href="@{/admin/companie_aerienne}" class="btn btn-secondary">Cancel</a>
+  </form>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/add-edit-vol.html
+++ b/server/src/main/resources/templates/admin/add-edit-vol.html
@@ -73,14 +73,9 @@
     <div class="mb-3">
       <label for="etat" class="form-label">État:</label>
       <select th:field="*{etat}" id="etat" class="form-control">
-        <option value="0">Prévu</option>
-        <option value="1">En vol</option>
-        <option value="2">Aterri</option>
-        <option value="3">Retardé</option>
-        <option value="4">Annulé</option>
-        <option value="5">Embarquement</option>
-        <option value="6">Fermé</option>
-      </select>
+        <option value="">Sélectionner un état</option>
+        <option th:each="etatOption : ${etatsVol}"
+                th:value="${etatOption.name()}"  th:text="${etatOption.name()}"       th:selected="${vol.etat != null && vol.etat.name() == etatOption.name()}"></option> </select>
       <div th:if="${#fields.hasErrors('etat')}" th:errors="*{etat}" class="text-danger">État Error</div>
     </div>
 

--- a/server/src/main/resources/templates/admin/add-edit-vol.html
+++ b/server/src/main/resources/templates/admin/add-edit-vol.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+  <h1 th:text="${pageTitle}"></h1>
+
+  <form th:action="@{/admin/vol/save}" th:object="${vol}" method="post">
+    <input type="hidden" th:field="*{id}" />
+
+    <div class="mb-3">
+      <label for="aeroportDepart" class="form-label">Aéroport de Départ:</label>
+      <select th:field="*{aeroportDepart}" id="aeroportDepart" class="form-control">
+        <option th:each="aeroport : ${aeroports}"
+                th:value="${aeroport.id}"
+                th:text="${aeroport.nom + ' (' + aeroport.iataCode + ')'}"
+                th:selected="${vol.aeroportDepart != null && vol.aeroportDepart.id == aeroport.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('aeroportDepart')}" th:errors="*{aeroportDepart}" class="text-danger">Aéroport de Départ Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="aeroportArrive" class="form-label">Aéroport d'Arrivée:</label>
+      <select th:field="*{aeroportArrive}" id="aeroportArrive" class="form-control">
+        <option th:each="aeroport : ${aeroports}"
+                th:value="${aeroport.id}"
+                th:text="${aeroport.nom + ' (' + aeroport.iataCode + ')'}"
+                th:selected="${vol.aeroportArrive != null && vol.aeroportArrive.id == aeroport.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('aeroportArrive')}" th:errors="*{aeroportArrive}" class="text-danger">Aéroport d'Arrivée Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="avion" class="form-label">Avion:</label>
+      <select th:field="*{avion}" id="avion" class="form-control">
+        <option th:each="avionOption : ${avions}"
+                th:value="${avionOption.id}"
+                th:text="${avionOption.model + ' (' + avionOption.iataCode + ')'}"
+                th:selected="${vol.avion != null && vol.avion.id == avionOption.id}"></option>
+      </select>
+      <div th:if="${#fields.hasErrors('avion')}" th:errors="*{avion}" class="text-danger">Avion Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="dateDepart" class="form-label">Date Départ:</label>
+      <input type="date" th:field="*{dateDepart}" id="dateDepart" class="form-control" />
+      <div th:if="${#fields.hasErrors('dateDepart')}" th:errors="*{dateDepart}" class="text-danger">Date Départ Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="heureDepart" class="form-label">Heure Départ:</label>
+      <input type="time" th:field="*{heureDepart}" id="heureDepart" class="form-control" step="1" /> <div th:if="${#fields.hasErrors('heureDepart')}" th:errors="*{heureDepart}" class="text-danger">Heure Départ Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="dateArrive" class="form-label">Date Arrivée:</label>
+      <input type="date" th:field="*{dateArrive}" id="dateArrive" class="form-control" />
+      <div th:if="${#fields.hasErrors('dateArrive')}" th:errors="*{dateArrive}" class="text-danger">Date Arrivée Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="heureArrive" class="form-label">Heure Arrivee:</label>
+      <input type="time" th:field="*{heureArrive}" id="heureArrive" class="form-control" step="1" /> <div th:if="${#fields.hasErrors('heureArrive')}" th:errors="*{heureArrive}" class="text-danger">Heure Arrivee Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="prix" class="form-label">Prix:</label>
+      <input type="number" th:field="*{prix}" id="prix" class="form-control" step="0.01" />
+      <div th:if="${#fields.hasErrors('prix')}" th:errors="*{prix}" class="text-danger">Prix Error</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="etat" class="form-label">État:</label>
+      <select th:field="*{etat}" id="etat" class="form-control">
+        <option value="0">Prévu</option>
+        <option value="1">En vol</option>
+        <option value="2">Aterri</option>
+        <option value="3">Retardé</option>
+        <option value="4">Annulé</option>
+        <option value="5">Embarquement</option>
+        <option value="6">Fermé</option>
+      </select>
+      <div th:if="${#fields.hasErrors('etat')}" th:errors="*{etat}" class="text-danger">État Error</div>
+    </div>
+
+
+    <button type="submit" class="btn btn-success">Sauvegarder Vol</button>
+    <a th:href="@{/admin/vol}" class="btn btn-secondary">Annuler</a>
+  </form>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/avion.html
+++ b/server/src/main/resources/templates/admin/avion.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+  <h1 th:text="${pageTitle}"></h1>
+
+  <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+  <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
+  <a th:href="@{/admin/avion/add}" class="btn btn-primary mb-3">Ajouter un nouvel Avion</a>
+
+  <table class="table table-striped table-bordered">
+    <thead class="table-dark">
+    <tr>
+      <th>ID</th>
+      <th>Modèle</th>
+      <th>IATA CODE</th>
+      <th>ICAO CODE</th>
+      <th>Max Distance</th>
+      <th>Compagnie Aérienne</th>
+      <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="avion : ${avions}">
+      <td th:text="${avion.id}">1</td>
+      <td th:text="${avion.model}"></td>
+      <td th:text="${avion.iataCode}"></td>
+      <td th:text="${avion.icaoCode}"></td>
+      <td th:text="${avion.maxDistance}"></td>
+      <td th:text="${avion.companieAerienne != null ? avion.companieAerienne.nom : 'N/A'}"></td> <td>
+      <a th:href="@{/admin/avion/details/{id}(id=${avion.id})}" class="btn btn-sm btn-info">Détails</a> <a th:href="@{/admin/avion/edit/{id}(id=${avion.id})}" class="btn btn-sm btn-warning">Modifier</a>
+      <a th:href="@{/admin/avion/delete/{id}(id=${avion.id})}"
+         onclick="return confirm('Êtes-vous sûr de vouloir supprimer cet avion ?')"
+         class="btn btn-sm btn-danger">Supprimer</a>
+    </td>
+    </tr>
+    <tr th:if="${#lists.isEmpty(avions)}">
+      <td colspan="7" class="text-center">Aucun avion trouvé.</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/billet.html
+++ b/server/src/main/resources/templates/admin/billet.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+    <h1 th:text="${pageTitle}"></h1>
+
+    <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+    <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
+    <a th:href="@{/admin/billet/add}" class="btn btn-primary mb-3">Ajouter un nouveau Billet</a>
+
+    <table class="table table-striped table-bordered">
+        <thead class="table-dark">
+        <tr>
+            <th>ID</th>
+            <th>Siège</th>
+            <th>Classe</th>
+            <th>Passager</th>
+            <th>Réservation</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="billet : ${billets}">
+            <td th:text="${billet.id}">1</td>
+            <td th:text="${billet.siege}"></td>
+            <td th:text="${billet.classe != null ? billet.classe.nom : 'N/A'}"></td>
+            <td th:text="${billet.passager != null ? billet.passager.prenom + ' ' + billet.passager.nom : 'N/A'}"></td>
+            <td th:text="${billet.reservation != null ? 'Res ID: ' + billet.reservation.id : 'N/A'}"></td>
+            <td>
+                <a th:href="@{/admin/billet/edit/{id}(id=${billet.id})}" class="btn btn-sm btn-warning">Modifier</a>
+                <a th:href="@{/admin/billet/delete/{id}(id=${billet.id})}"
+                   onclick="return confirm('Êtes-vous sûr de vouloir supprimer ce billet ?')"
+                   class="btn btn-sm btn-danger">Supprimer</a>
+            </td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(billets)}">
+            <td colspan="6" class="text-center">Aucun billet trouvé.</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/companie_aerienne.html
+++ b/server/src/main/resources/templates/admin/companie_aerienne.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+    <h1 th:text="${pageTitle}">Companie Aeriennes</h1>
+
+    <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+    <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
+    <a th:href="@{/admin/companie_aerienne/add}" class="btn btn-primary mb-3">Add New Companie Aeriennes</a>
+
+    <table class="table table-striped table-bordered">
+        <thead class="table-dark">
+        <tr>
+            <th>ID</th>
+            <th>Nom</th>
+            <th>IATA CODE</th>
+            <th>ICAO CODE</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="ca : ${companiesAerienne}">
+            <td th:text="${ca.id}">1</td>
+            <td th:text="${ca.nom}"></td>
+            <td th:text="${ca.iataCode}"></td>
+            <td th:text="${ca.icaoCode}"></td><td>
+            <a th:href="@{/admin/companie_aerienne/edit/{id}(id=${ca.id})}" class="btn btn-sm btn-warning">Edit</a>
+            <a th:href="@{/admin/companie_aerienne/delete/{id}(id=${ca.id})}"
+               onclick="return confirm('Are you sure you want to delete this companie aerienne?')"
+               class="btn btn-sm btn-danger">Delete</a>
+        </td>
+        </tr>
+        <tr th:if="${#lists.isEmpty(companiesAerienne)}">
+            <td colspan="5" class="text-center">No classes found.</td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/dashboard.html
+++ b/server/src/main/resources/templates/admin/dashboard.html
@@ -46,6 +46,44 @@
                 </div>
             </div>
         </div>
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Manage Classes</h5> <p class="card-text">Add, edit, or delete passenger classes.</p>
+                    <a th:href="@{/admin/classes}" class="btn btn-primary">Go to Classes</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Manage Compagnies</h5>
+                    <p class="card-text">Add, edit, or delete airline companies.</p>
+                    <a th:href="@{/admin/companie_aerienne}" class="btn btn-primary">Go to Compagnies</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Manage Avions</h5>
+                    <p class="card-text">Add, edit, or delete aircraft.</p>
+                    <a th:href="@{/admin/avion}" class="btn btn-primary">Go to Avions</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Manage Vols</h5>
+                    <p class="card-text">Add, edit, or delete flights.</p>
+                    <a th:href="@{/admin/vol}" class="btn btn-primary">Go to Vols</a>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 </body>

--- a/server/src/main/resources/templates/admin/fragments/header.html
+++ b/server/src/main/resources/templates/admin/fragments/header.html
@@ -3,7 +3,8 @@
 <head th:fragment="common-header(pageTitle)">
   <meta charset="UTF-8">
   <title th:text="${pageTitle} + ' - Airline Admin'"></title>
-  <link rel="stylesheet" th:href="@{/css/admin-style.css}"> <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" th:href="@{/css/admin-style.css}">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
 <nav th:fragment="navbar" class="navbar navbar-expand-lg navbar-dark bg-dark">
@@ -25,6 +26,17 @@
         </li>
         <li class="nav-item">
           <a class="nav-link" th:href="@{/admin/aeroports}">Gérer les Aéroports</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" th:href="@{/admin/classes}">Gérer les Classes</a> </li>
+        <li class="nav-item">
+          <a class="nav-link" th:href="@{/admin/companie_aerienne}">Gérer les Compagnies</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" th:href="@{/admin/avion}">Gérer les Avions</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" th:href="@{/admin/vol}">Gérer les Vols</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" th:href="@{/admin/statistics/occupancy}">Occupancy Stats</a>

--- a/server/src/main/resources/templates/admin/view-avion.html
+++ b/server/src/main/resources/templates/admin/view-avion.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+    <h1 th:text="${pageTitle}"></h1>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            Informations sur l'Avion
+        </div>
+        <div class="card-body">
+            <p><strong>ID:</strong> <span th:text="${avion.id}"></span></p>
+            <p><strong>Modèle:</strong> <span th:text="${avion.model}"></span></p>
+            <p><strong>IATA CODE:</strong> <span th:text="${avion.iataCode}"></span></p>
+            <p><strong>ICAO CODE:</strong> <span th:text="${avion.icaoCode}"></span></p>
+            <p><strong>Distance Maximale:</strong> <span th:text="${avion.maxDistance}"></span></p>
+            <p><strong>Compagnie Aérienne:</strong> <span th:text="${avion.companieAerienne != null ? avion.companieAerienne.nom : 'N/A'}"></span></p>
+        </div>
+        <div class="card-footer">
+            <a th:href="@{/admin/avion/edit/{id}(id=${avion.id})}" class="btn btn-warning me-2">Modifier cet Avion</a>
+            <a th:href="@{/admin/avion}" class="btn btn-secondary">Retour à la liste des Avions</a>
+        </div>
+    </div>
+
+    <div class="mt-5">
+        <h2>Capacités</h2>
+        <a th:href="@{/admin/capacite/add(avionId=${avion.id})}" class="btn btn-primary mb-3">Ajouter une nouvelle Capacité pour cet Avion</a>
+
+
+        <table class="table table-striped table-bordered">
+            <thead class="table-dark">
+            <tr>
+                <th>ID</th>
+                <th>Borne Inf</th>
+                <th>Borne Sup</th>
+                <th>Capacité</th>
+                <th>Classe</th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="capacite : ${avion.capacites}"> <td th:text="${capacite.id}"></td>
+                <td th:text="${capacite.borneInf}"></td>
+                <td th:text="${capacite.borneSup}"></td>
+                <td th:text="${capacite.capacite}"></td>
+                <td th:text="${capacite.classe != null ? capacite.classe.nom : 'N/A'}"></td> <td>
+                    <a th:href="@{/admin/capacite/edit/{id}(id=${capacite.id})}" class="btn btn-sm btn-warning">Modifier</a>
+                    <a th:href="@{/admin/capacite/delete/{id}(id=${capacite.id})}"
+                       onclick="return confirm('Êtes-vous sûr de vouloir supprimer cette capacité ?')"
+                       class="btn btn-sm btn-danger">Supprimer</a>
+                </td>
+            </tr>
+            <tr th:if="${#lists.isEmpty(avion.capacites)}">
+                <td colspan="6" class="text-center">Aucune capacité trouvée pour cet avion.</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+</body>
+</html>

--- a/server/src/main/resources/templates/admin/vol.html
+++ b/server/src/main/resources/templates/admin/vol.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{admin/fragments/header :: common-header(pageTitle=${pageTitle})}"></head>
+<body>
+<nav th:replace="~{admin/fragments/header :: navbar}"></nav>
+<div class="container mt-4">
+  <h1 th:text="${pageTitle}"></h1>
+
+  <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+  <div th:if="${errorMessage}" class="alert alert-danger" th:text="${errorMessage}"></div>
+
+  <a th:href="@{/admin/vol/add}" class="btn btn-primary mb-3">Ajouter un nouveau Vol</a>
+
+  <table class="table table-striped table-bordered">
+    <thead class="table-dark">
+    <tr>
+      <th>ID</th>
+      <th>Aéroport de Départ</th>
+      <th>Aéroport d'Arrivée</th>
+      <th>Avion</th>
+      <th>Date Départ</th>
+      <th>Heure Départ</th>
+      <th>Date Arrivée</th>
+      <th>Heure Arrivée</th>
+      <th>Prix</th>
+      <th>État</th>
+      <th>Actions</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="vol : ${vols}">
+      <td th:text="${vol.id}">1</td>
+      <td th:text="${vol.aeroportDepart != null ? vol.aeroportDepart.nom : 'N/A'}"></td>
+      <td th:text="${vol.aeroportArrive != null ? vol.aeroportArrive.nom : 'N/A'}"></td>
+      <td th:text="${vol.avion != null ? vol.avion.model : 'N/A'}"></td>
+      <td th:text="${vol.dateDepart}"></td>
+      <td th:text="${vol.heureDepart}"></td>
+      <td th:text="${vol.dateArrive}"></td>
+      <td th:text="${vol.heureArrive}"></td>
+      <td th:text="${vol.prix}"></td>
+      <td th:text="${vol.etat}"></td> <td>
+      <a th:href="@{/admin/vol/edit/{id}(id=${vol.id})}" class="btn btn-sm btn-warning">Modifier</a>
+      <a th:href="@{/admin/vol/delete/{id}(id=${vol.id})}"
+         onclick="return confirm('Êtes-vous sûr de vouloir supprimer ce vol ?')"
+         class="btn btn-sm btn-danger">Supprimer</a>
+    </td>
+    </tr>
+    <tr th:if="${#lists.isEmpty(vols)}">
+      <td colspan="11" class="text-center">Aucun vol trouvé.</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This is an explanation of why I made some changes to certain entities, and why I might need to do it again in the future.
The short answer:
Optimize Entity Fetching and Prevent Recursive Loading Issues

The not-so-short answer:
Problem:
During development and testing of administration features (listing, adding, editing, saving entities like CompanieAerienne, Avion, Capacite, Vol, etc.), the application experienced significant performance degradation, excessive database queries (N+1 problems), and errors (including StackOverflowError, ConcurrentModificationException, and generic save failures resulting in a black page). These issues were caused by the application attempting to fetch large and complex interconnected graphs of entities from the database when only limited information was required.

Cause:
The core problem was the unintended eager fetching of related entities combined with recursive calls in entity methods:
1. Default fetch types (e.g., @ManyToOne is EAGER by default) led to Hibernate fetching entire relationship trees unnecessarily.
2. Lombok's @Data annotation generated toString(), equals(), and hashCode() methods that included all fields, including lazy-loaded relationships. When these methods were called by Thymeleaf/Spring binding processes, they triggered the initialization of lazy collections and associations, leading to deep, recursive fetching across the entity graph and causing performance bottlenecks and errors like StackOverflowError and ConcurrentModificationException during collection loading.

Solution:
Modified JPA entity classes across the domain model to control fetching behavior and prevent recursive issues:
1. Added @ToString.Exclude and @EqualsAndHashCode.Exclude annotations to all relationship fields (@OneToMany, @ManyToOne, @ManyToMany, @OneToOne). This excludes relationship data from generated core methods, preventing unintended lazy loading triggers and eliminating recursion errors.
2. Explicitly set FetchType.LAZY on @ManyToOne and @OneToOne relationships where eager fetching was not required for immediate use. @OneToMany and @ManyToMany are typically lazy by default, but their configurations were reviewed.

This resolves the N+1 query problems and prevents the errors (StackOverflowError, ConcurrentModificationException, save failures) caused by loading overly large object graphs. The administration interface is now more responsive and stable.